### PR TITLE
chore: update repository template to 9b2207f6

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,5 @@
+# These are supported funding model platforms
+
+# github:
+patreon: _ory
+open_collective: ory

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Create a report to help us improve
+---
+
+**Describe the bug**
+
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+
+Steps to reproduce the behavior:
+
+<!--
+1. Call function `foo.Bar`
+2. Function returns invalid value `baz`
+-->
+
+**Expected behavior**
+
+A clear and concise description of what you expected to happen.
+
+**Environment**
+
+- Version: v1.2.3, git sha hash
+- Environment: Debian, Docker, ...
+
+**Additional context**
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: ORY Community
+    url: https://community.ory.sh/
+    about: Please ask and answer questions here.
+  - name: ORY Chat
+    url: https://www.ory.sh/chat
+    about: Hang out with other ORY community members and ask and answer questions.
+  - name: ORY Enterprise Contact
+    url: https://www.ory.sh/contact
+    about: Jared will help you with your enterprise-related inquiries.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+---
+
+**Is your feature request related to a problem? Please describe.**
+
+A clear and concise description of what the problem is. Ex. I'm always
+frustrated when [...]
+
+**Describe the solution you'd like**
+
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+
+A clear and concise description of any alternative solutions or features you've
+considered.
+
+**Additional context**
+
+Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,42 @@
+## Related issue
+
+<!--
+Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
+with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).
+
+If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
+chance substantial changes will be requested or that the changes will be rejected.
+
+You can discuss changes with maintainers either in the [ORY Community Forums](https://community.ory.sh/) or
+join the [ORY Chat](https://www.ory.sh/chat).
+-->
+
+## Proposed changes
+
+<!--
+Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
+-->
+
+## Checklist
+
+<!--
+Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
+them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
+-->
+
+- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
+- [ ] I have read the [security policy](../security/policy).
+- [ ] I confirm that this pull request does not address a security
+      vulnerability. If this pull request addresses a security vulnerability, I
+      confirm that I got green light (please contact
+      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
+      the changes.
+- [ ] I have added tests that prove my fix is effective or that my feature works.
+- [ ] I have added necessary documentation within the code base (if appropriate).
+
+## Further comments
+
+<!--
+If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
+you did and what alternatives you considered, etc...
+-->

--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,17 @@
+titleOnly: true
+commitsOnly: false
+titleAndCommits: false
+
+types:
+  - feat
+  - fix
+  - revert
+  - docs
+  - style
+  - refactor
+  - test
+  - build
+  - autogen
+  - security
+  - ci
+  - chore

--- a/.github/workflows/closed_references.yml
+++ b/.github/workflows/closed_references.yml
@@ -1,0 +1,27 @@
+name: Closed Reference Notifier
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+    inputs:
+      issueLimit:
+        description: Max. number of issues to create
+        required: true
+        default: '5'
+
+jobs:
+  find_closed_references:
+    if: github.repository_owner == 'ory'
+    runs-on: ubuntu-latest
+    name: Find closed references
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: '14'
+      - uses: ory/closed-reference-notifier@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issueLabels: upstream,good first issue,help wanted
+          issueLimit: ${{ github.event.inputs.issueLimit || '5' }}

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,22 @@
+name: Synchronize Issue Labels
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+
+jobs:
+  milestone:
+    if: github.repository_owner == 'ory'
+    name: Synchronize Issue Labels
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Synchronize Issue Labels
+        uses: ory/label-sync-action@v0
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          dry: false
+          forced: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,25 @@
+name: "Close Stale Issues"
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    if: github.repository_owner == 'ory'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: |
+            Thank you for opening this issue. It appears that the request for more information (e.g. providing the software version, providing logs, ...) has not yet been completed. Therefore this issue will be automatically
+            closed in 7 days, assuming that the issue has been resolved.
+          stale-pr-message: |
+            Thank you for opening this pull request. It appears that a request for e.g. information has not yet been completed. Therefore this issue will be automatically
+            closed in 7 days, assuming that the proposed change is no longer required or has otherwise been resolved.
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          only-labels: 'needs more info'
+          days-before-stale: 7
+          days-before-close: 7

--- a/.reference-ignore
+++ b/.reference-ignore
@@ -1,0 +1,3 @@
+**/node_modules
+docs
+CHANGELOG.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,194 @@
+<!--
+
+Thank you for contributing changes to this document! Because we use a central repository
+to synchronize this file across all our repositories, make sure to make your edits
+in the correct file, which you can find here:
+
+https://github.com/ory/meta/blob/master/templates/repository/CONTRIBUTING.md
+
+-->
+
+# Contributing to ORY {{Project}}
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Introduction](#introduction)
+- [Contributing Code](#contributing-code)
+- [Disclosing vulnerabilities](#disclosing-vulnerabilities)
+- [Code Style](#code-style)
+- [Documentation](#documentation)
+- [Pull request procedure](#pull-request-procedure)
+- [Communication](#communication)
+- [Conduct](#conduct)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Introduction
+
+Please note: We take ORY {{Project}}'s security and our users' trust very
+seriously. If you believe you have found a security issue in ORY {{Project}},
+please responsibly disclose by contacting us at office@ory.sh.
+
+First: if you're unsure or afraid of anything, just ask or submit the issue or
+pull request anyways. You won't be yelled at for giving it your best effort. The
+worst that can happen is that you'll be politely asked to change something. We
+appreciate any sort of contributions, and don't want a wall of rules to get in
+the way of that.
+
+That said, if you want to ensure that a pull request is likely to be merged,
+talk to us! You can find out our thoughts and ensure that your contribution
+won't clash or be obviated by ORY {{Project}}'s normal direction. A great way to
+do this is via the [ORY Community](https://community.ory.sh/) or join the
+[ORY Chat](https://www.ory.sh/chat).
+
+## Contributing Code
+
+Unless you are fixing a known bug, we **strongly** recommend discussing it with
+the core team via a GitHub issue or [in our chat](https://www.ory.sh/chat)
+before getting started to ensure your work is consistent with ORY {{Project}}'s
+roadmap and architecture.
+
+All contributions are made via pull request. Note that **all patches from all
+contributors get reviewed**. After a pull request is made other contributors
+will offer feedback, and if the patch passes review a maintainer will accept it
+with a comment. When pull requests fail testing, authors are expected to update
+their pull requests to address the failures until the tests pass and the pull
+request merges successfully.
+
+At least one review from a maintainer is required for all patches (even patches
+from maintainers).
+
+Reviewers should leave a "LGTM" comment once they are satisfied with the patch.
+If the patch was submitted by a maintainer with write access, the pull request
+should be merged by the submitter after review.
+
+## Disclosing vulnerabilities
+
+Please disclose vulnerabilities exclusively to
+[security@ory.sh](mailto:security@ory.sh). Do not use GitHub issues.
+
+## Code Style
+
+Please follow these guidelines when formatting source code:
+
+- Go code should match the output of `gofmt -s` and pass `golangci-lint run`.
+- NodeJS and JavaScript code should be prettified using `npm run format` where
+  appropriate.
+
+## Documentation
+
+Please provide documentation when changing, removing, or adding features.
+Documentation resides in the project's `docs` folder.
+
+In cases where a project does not have a `docs` folder check the README for instructions.
+
+The commands listed below work exclusively for projects with a `docs` folder
+
+### Develop
+
+To change the documentation locally, you need NodeJS installed and the project
+checked out locally. Next, `cd` into `docs` and install the dependencies:
+
+```shell script
+$ cd docs
+$ npm install
+```
+
+#### Start
+
+To start a local development server with hot reloading, run:
+
+```shell script
+$ npm start
+```
+
+This command opens up a browser window. Please note that changes to the sidebar are not hot-reloaded
+and require a restart of the command.
+
+#### Build
+
+The `npm build` generates static content into the `build` directory and can be
+served using any static contents hosting service.
+
+```shell script
+$ npm build
+```
+
+## Pull request procedure
+
+To make a pull request, you will need a GitHub account; if you are unclear on
+this process, see GitHub's documentation on
+[forking](https://help.github.com/articles/fork-a-repo) and
+[pull requests](https://help.github.com/articles/using-pull-requests). Pull
+requests should be targeted at the `master` branch. Before creating a pull
+request, go through this checklist:
+
+1. Create a feature branch off of `master` so that changes do not get mixed up.
+1. [Rebase](http://git-scm.com/book/en/Git-Branching-Rebasing) your local
+   changes against the `master` branch.
+1. Run the full project test suite with the `go test ./...` (or equivalent)
+   command and confirm that it passes.
+1. Run `gofmt -s` (if the project is written in Go).
+1. Ensure that each commit has a subsystem prefix (ex: `controller:`).
+
+Pull requests will be treated as "review requests," and maintainers will give
+feedback on the style and substance of the patch.
+
+Normally, all pull requests must include tests that test your change.
+Occasionally, a change will be very difficult to test for. In those cases,
+please include a note in your commit message explaining why.
+
+## How We Organize Our Work
+
+All repositories in the [ORY organization](https://github.com/ory) have their issues and pull requests
+monitored in the [ORY Monitoring Board](https://github.com/orgs/ory/projects/9). This allows
+for a transparent backlog of unanswered issues and pull requests across the ecosystem from those
+who are allowed to merge pull requests to the main branch.
+
+The process is as follows:
+
+1. _Cards_ represent open issues and pull requests and are automatically assigned to the **Triage** column if
+   the author is not one of the maintainers and no maintainer has answered yet.
+2. A maintainer assigns the issue or pull request to someone or adds the label _help wanted_
+   which moves the card to **Requires Action**.
+3. If a maintainer leaves a comment or review, the card moves to **Pending Reply**, implying that
+   the original author needs to do something (e.g. implement a change, explain something in more detail, ...).
+4. If a non-maintainer pushes changes to the pull request or leaves a comment, the card moves
+   back to **Requires Action**.
+5. If a card stays inactive for 60 days or more days, we assume that public interest in the issue
+   or change has waned, **archiving** the card.
+6. If the issue is closed or the pull request merged or closed, the card is **archived** as well.
+
+We try our best to answer all issues and review all pull requests and hope that this transparent way
+of keeping a backlog helps you better understand how heavy the workload is.
+
+## Communication
+
+We use [Slack](https://www.ory.sh/chat). You are welcome to drop in and ask
+questions, discuss bugs, etc.
+
+## Conduct
+
+Whether you are a regular contributor or a newcomer, we care about making this
+community a safe place for you and we've got your back.
+
+- We are committed to providing a friendly, safe and welcoming environment for
+  all, regardless of gender, sexual orientation, disability, ethnicity,
+  religion, or similar personal characteristic.
+- Please avoid using nicknames that might detract from a friendly, safe and
+  welcoming environment for all.
+- Be kind and courteous. There is no need to be mean or rude.
+- We will exclude you from interaction if you insult, demean or harass anyone.
+  In particular, we do not tolerate behavior that excludes people in socially
+  marginalized groups.
+- Private harassment is also unacceptable. No matter who you are, if you feel
+  you have been or are being harassed or made uncomfortable by a community
+  member, please contact one of the channel ops or a member of the ORY
+  {{Project}} core team immediately.
+- Likewise any spamming, trolling, flaming, baiting or other attention-stealing
+  behaviour is not welcome.
+
+We welcome discussion about creating a welcoming, safe, and productive
+environment for the community. If you have any questions, feedback, or concerns
+[please let us know](https://www.ory.sh/chat).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,37 @@
+<!--
+
+Thank you for contributing changes to this document! Because we use a central repository
+to synchronize this file across all our repositories, make sure to make your edits
+in the correct file, which you can find here:
+
+https://github.com/ory/meta/blob/master/templates/repository/SECURITY.md
+
+-->
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Security Policy](#security-policy)
+  - [Supported Versions](#supported-versions)
+  - [Reporting a Vulnerability](#reporting-a-vulnerability)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# Security Policy
+
+## Supported Versions
+
+We release patches for security vulnerabilities. Which versions are eligible
+receiving such patches depend on the CVSS v3.0 Rating:
+
+| CVSS v3.0 | Supported Versions                        |
+| --------- | ----------------------------------------- |
+| 9.0-10.0  | Releases within the previous three months |
+| 4.0-8.9   | Most recent release                       |
+
+## Reporting a Vulnerability
+
+Please report (suspected) security vulnerabilities to
+**[security@ory.sh](mailto:security@ory.sh)**. You will receive a response from
+us within 48 hours. If the issue is confirmed, we will release a patch as soon
+as possible depending on complexity but historically within a few days.


### PR DESCRIPTION
Updated repository templates to https://github.com/ory/meta/commit/9b2207f6375d776660ec08b600aee0b11fc9b04e.