### PR TITLE
chore: update repository template to ad9a6404

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 blank_issues_enabled: false
 contact_links:
-  - name: ORY Works Forum
+  - name: Ory Works Forum
     url: https://github.com/ory/works/discussions
     about: Please ask and answer questions here, show your implementations and discuss ideas.
-  - name: ORY Chat
+  - name: Ory Chat
     url: https://www.ory.sh/chat
-    about: Hang out with other ORY community members and ask and answer questions.
-  - name: ORY Support for Business
+    about: Hang out with other Ory community members and ask and answer questions.
+  - name: Ory Support for Business
     url: https://github.com/ory/open-source-support/blob/master/README.md
-    about: Buy professional support for ORY Works.
+    about: Buy professional support for Ory Works.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@ If this change neither resolves an existing issue nor has sign-off from one of t
 chance substantial changes will be requested or that the changes will be rejected.
 
 You can discuss changes with maintainers either in the Github Discusssions in this repository or
-join the [ORY Chat](https://www.ory.sh/chat).
+join the [Ory Chat](https://www.ory.sh/chat).
 -->
 
 ## Proposed changes

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,77 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and
+expression, level of experience, education, socio-economic status, nationality,
+personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, or to ban temporarily or permanently any
+contributor for other behaviors that they deem inappropriate, threatening,
+offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at office@ory.sh. All complaints will be
+reviewed and investigated and will result in a response that is deemed necessary
+and appropriate to the circumstances. The project team is obligated to maintain
+confidentiality with regard to the reporter of an incident. Further details of
+specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 1.4, available at
+https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ https://github.com/ory/meta/blob/master/templates/repository/common/CONTRIBUTING
 
 -->
 
-# Contributing to ORY Works
+# Contributing to Ory Works
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -33,8 +33,8 @@ There are many ways in which you can contribute, beyond writing code. The goal
 of this document is to provide a high-level overview of how you can get
 involved.
 
-_Please note_: We take ORY Works's security and our users' trust very
-seriously. If you believe you have found a security issue in ORY Works,
+_Please note_: We take Ory Works's security and our users' trust very
+seriously. If you believe you have found a security issue in Ory Works,
 please responsibly disclose by contacting us at security@ory.sh.
 
 First: As a potential contributor, your changes and ideas are welcome at any
@@ -48,33 +48,33 @@ contributions, and don't want a wall of rules to get in the way of that.
 
 That said, if you want to ensure that a pull request is likely to be merged,
 talk to us! You can find out our thoughts and ensure that your contribution
-won't clash or be obviated by ORY
+won't clash or be obviated by Ory
 Works's normal direction. A great way to
 do this is via
-[ORY Works Discussions](https://github.com/ory/meta/discussions)
-or the [ORY Chat](https://www.ory.sh/chat).
+[Ory Works Discussions](https://github.com/ory/meta/discussions)
+or the [Ory Chat](https://www.ory.sh/chat).
 
 ## FAQ
 
 - I am new to the community. Where can I find the
-  [ORY Community Code of Conduct?](https://github.com/ory/works/blob/master/CODE_OF_CONDUCT.md)
+  [Ory Community Code of Conduct?](https://github.com/ory/works/blob/master/CODE_OF_CONDUCT.md)
 
 - I have a question. Where can I get
-  [answers to questions regarding ORY Works?](#communication)
+  [answers to questions regarding Ory Works?](#communication)
 
 - I would like to contribute but I am not sure how. Are there
   [easy ways to contribute?](#how-can-i-contribute)
   [Or good first issues?](https://github.com/search?l=&o=desc&q=label%3A%22help+wanted%22+label%3A%22good+first+issue%22+is%3Aopen+user%3Aory+user%3Aory-corp&s=updated&type=Issues)
 
-- I want to talk to other ORY Works users.
+- I want to talk to other Ory Works users.
   [How can I become a part of the community?](#communication)
 
-- I would like to know what I am agreeing to when I contribute to ORY
+- I would like to know what I am agreeing to when I contribute to Ory
   Works.
-  Does ORY have
+  Does Ory have
   [a Contributors License Agreement?](https://cla-assistant.io/ory/works)
 
-- I would like updates about new versions of ORY Works.
+- I would like updates about new versions of Ory Works.
   [How are new releases announced?](https://ory.us10.list-manage.com/subscribe?u=ffb1a878e4ec6c0ed312a3480&id=f605a41b53)
 
 ## How can I contribute?
@@ -86,7 +86,7 @@ There are many other ways you can contribute without writing any code. Here are
 a few things you can do to help out:
 
 - **Give us a star.** It may not seem like much, but it really makes a
-  difference. This is something that everyone can do to help out ORY Works.
+  difference. This is something that everyone can do to help out Ory Works.
   Github stars help the project gain visibility and stand out.
 
 - **Join the community.** Sometimes helping people can be as easy as listening
@@ -94,7 +94,7 @@ a few things you can do to help out:
   look at discussions in the forum and take part in our weekly hangout. More
   info on this in [Communication](#communication).
 
-- **Helping with open issues.** We have a lot of open issues for ORY Works
+- **Helping with open issues.** We have a lot of open issues for Ory Works
   and some of them may lack necessary information, some are duplicates of older
   issues. You can help out by guiding people through the process of filling out
   the issue template, asking for clarifying information, or pointing them to
@@ -111,16 +111,16 @@ a few things you can do to help out:
 ## Communication
 
 We use [Slack](https://www.ory.sh/chat). You are welcome to drop in and ask
-questions, discuss bugs and feature requests, talk to other users of ORY, etc.
+questions, discuss bugs and feature requests, talk to other users of Ory, etc.
 
-Check out [ORY Works Discussions](https://github.com/ory/meta/discussions). This is a great place for
+Check out [Ory Works Discussions](https://github.com/ory/meta/discussions). This is a great place for
 in-depth discussions and lots of code examples, logs and similar data.
 
-You can also join our community hangout, if you want to speak to the ORY team
+You can also join our community hangout, if you want to speak to the Ory team
 directly or ask some questions. You can find more info on the hangouts in
 [Slack](https://www.ory.sh/chat).
 
-If you want to receive regular notifications about updates to ORY Works,
+If you want to receive regular notifications about updates to Ory Works,
 consider joining the mailing list. We will _only_ send you vital information on
 the projects that you are interested in.
 
@@ -130,7 +130,7 @@ Also [follow us on twitter](https://twitter.com/orycorp).
 
 Unless you are fixing a known bug, we **strongly** recommend discussing it with
 the core team via a GitHub issue or [in our chat](https://www.ory.sh/chat)
-before getting started to ensure your work is consistent with ORY Works's
+before getting started to ensure your work is consistent with Ory Works's
 roadmap and architecture.
 
 All contributions are made via pull request. Note that **all patches from all
@@ -147,7 +147,7 @@ from maintainers).
 Before your contributions can be merged you need to sign our
 [Contributor License Agreement](https://cla-assistant.io/ory/works).
 
-This agreement defines the terms under which your code is contributed to ORY.
+This agreement defines the terms under which your code is contributed to Ory.
 More specifically it declares that you have the right to, and actually do, grant
 us the rights to use your contribution. You can see the Apache 2.0 license under
 which our projects are published
@@ -195,7 +195,10 @@ request, go through this checklist:
 1. Run the full project test suite with the `go test ./...` (or equivalent)
    command and confirm that it passes.
 1. Run `gofmt -s` (if the project is written in Go).
-1. Ensure that each commit has a subsystem prefix (ex: `controller:`).
+1. Ensure that each commit has a descriptive prefix. This ensures a uniform
+   commit history and helps structure the changelog.  
+   Please refer to this
+   [list of prefixes for Works](https://github.com/ory/works/blob/master/.github/semantic.yml).
 
 Pull requests will be treated as "review requests," and maintainers will give
 feedback on the style and substance of the patch.
@@ -247,7 +250,7 @@ community a safe place for you and we've got your back.
   marginalized groups.
 - Private harassment is also unacceptable. No matter who you are, if you feel
   you have been or are being harassed or made uncomfortable by a community
-  member, please contact one of the channel ops or a member of the ORY Works
+  member, please contact one of the channel ops or a member of the Ory Works
   core team immediately.
 - Likewise any spamming, trolling, flaming, baiting or other attention-stealing
   behaviour is not welcome.


### PR DESCRIPTION
Updated repository templates to https://github.com/ory/meta/commit/ad9a6404080b7fb14d2d265ac0a2d4b685624d9b.